### PR TITLE
Widget fixes

### DIFF
--- a/uawidgets/attrs_widget.py
+++ b/uawidgets/attrs_widget.py
@@ -246,7 +246,7 @@ class MyDelegate(QStyledItemDelegate):
 def data_type_to_string(dv):
     # a bit too complex, we could just display browse name of node but it requires a query
     if isinstance(dv.Value.Value.Identifier, int) and dv.Value.Value.Identifier < 63:
-        string = ua.DataType_to_VariantType(dv.Value.Value).name
+        string = ua.datatype_to_varianttype(dv.Value.Value).name
     elif dv.Value.Value.Identifier in ua.ObjectIdNames:
         string = ua.ObjectIdNames[dv.Value.Value.Identifier]
     else:

--- a/uawidgets/attrs_widget.py
+++ b/uawidgets/attrs_widget.py
@@ -229,8 +229,14 @@ class MyDelegate(QStyledItemDelegate):
                 text = editor.currentText()
             else:
                 text = editor.text()
+
             try:
-                dv.Value = string_to_variant(text, dv.Value.VariantType)
+                # if user is setting a value on a null variant, try using the nodes datatype instead
+                if dv.Value.VariantType is ua.VariantType.Null:
+                    dtype = self.attrs_widget.current_node.get_data_type_as_variant_type()
+                    dv.Value = string_to_variant(text, dtype)
+                else:
+                    dv.Value = string_to_variant(text, dv.Value.VariantType)
             except Exception as ex:
                 self.error.emit(ex)
                 raise

--- a/uawidgets/new_node_dialogs.py
+++ b/uawidgets/new_node_dialogs.py
@@ -41,11 +41,11 @@ class NewNodeBaseDialog(QDialog):
         self.layout.addWidget(self.nodeidCheckBox)
         self.nodeidLineEdit = QLineEdit(self)
         self.nodeidLineEdit.setMinimumWidth(80)
-        self.nodeidLineEdit.setText(self.settings.value("last_nodeid_type", "i=20000"))
+        self.nodeidLineEdit.setText(self.settings.value("last_nodeid_prefix", "ns={};i=20000".format(nsidx)))
         self.layout.addWidget(self.nodeidLineEdit)
 
         # restore check box state from settings
-        if self.settings.value("last_auto_nodeid_state", True) == "false":
+        if self.settings.value("last_node_widget_vis", False) == "true":
             self.nodeidCheckBox.setChecked(False)
             self.nodeidLineEdit.show()
         else:
@@ -61,8 +61,9 @@ class NewNodeBaseDialog(QDialog):
 
     def _store_state(self):
         self.settings.setValue("last_namespace", self.nsComboBox.currentIndex())
-        self.settings.setValue("last_auto_nodeid_state", self.nodeidCheckBox.isChecked())
-        self.settings.setValue("last_nodeid_type", self.nodeidLineEdit.text()[0:2])
+        self.settings.setValue("last_node_widget_vis", not self.nodeidCheckBox.isChecked())
+        ns_nt = self.nodeidLineEdit.text().split(';')
+        self.settings.setValue("last_nodeid_prefix", ns_nt[0] + ';' + ns_nt[1][0:2])
 
     def _show_nodeid(self, val):
         if val:
@@ -78,8 +79,7 @@ class NewNodeBaseDialog(QDialog):
         if self.nodeidCheckBox.isChecked():
             nodeid = ua.NodeId(namespaceidx=ns)
         else:
-            ns_nodeid = "ns={};".format(ns) + self.nodeidLineEdit.text()
-            nodeid = ua.NodeId.from_string(ns_nodeid)
+            nodeid = ua.NodeId.from_string(self.nodeidLineEdit.text())
         return nodeid, bname
 
     def get_args(self):


### PR DESCRIPTION
See commits.

Improve add node widget to better remember what user last did
Change attrs widget so that user can try to write to a node that has a Null Variant, even though it's data type is something else.
